### PR TITLE
Remove lua from tree-sitter config

### DIFF
--- a/after/plugin/treesitter.lua
+++ b/after/plugin/treesitter.lua
@@ -2,7 +2,7 @@
 -- See `:help nvim-treesitter`
 require('nvim-treesitter.configs').setup {
   -- Add languages to be installed here that you want installed for treesitter
-  ensure_installed = { 'c', 'cpp', 'go', 'lua', 'python', 'rust', 'tsx', 'typescript', 'vimdoc', 'vim' },
+  ensure_installed = { 'c', 'cpp', 'go', 'python', 'rust', 'tsx', 'typescript', 'vimdoc', 'vim' },
 
   -- Autoinstall languages that are not installed. Defaults to false (but you can change for yourself!)
   auto_install = false,

--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,5 @@
 -- Load main configuration
+
 require('main')
 
 -- vim: ts=2 sts=2 sw=2 et


### PR DESCRIPTION
Bitdefender is detecting the lua parser as being compromised.